### PR TITLE
Remove the custom service worker

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -1,6 +1,0 @@
-importScripts('workbox-v3.4.1/workbox-sw.js')
-
-self.workbox.skipWaiting();
-self.workbox.clientsClaim();
-
-self.workbox.precaching.precacheAndRoute([]);

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,15 +2,7 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   outputTargets: [
-    {
-      type: 'www',
-      serviceWorker: {
-        swSrc: 'src/sw.js',
-        globPatterns: [
-          '**/*.{html,js,css,json,ico,png}'
-        ]
-      }
-    }
+    { type: 'www' }
   ],
   globalStyle: 'src/global.css',
   copy: [


### PR DESCRIPTION
As discussed with @adamdbradley, this removes the custom service worker code, and relies on the default service worker instead that is generated using Workbox (`generateSW` mode).

See https://github.com/ionic-team/stencil-site/pull/246.